### PR TITLE
Add new ldd-corral utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For help with the PDS Engineering Node, you can either create a ticket in [Githu
 
 Prior to installing this software, ensure your system meets the following requirements:
 
-* Python 3. This software requires Python 3; it will work with 3.6, 3.7, or 3.8. Python 2 will absolutely not work, and indeed Python 2 came to its end of life on the first of January, 2020. Run python3 
+* **Python 3**: This software requires Python 3; it will work with 3.6, 3.7, or 3.8. Python 2 will absolutely not work, and indeed Python 2 came to its end of life January 2020. Run python3 
 
 Consult your operating system instructions or system administrator to install the required packages. For those without system administrator access and are feeling anxious, you could try a local (home directory) Python 3 installation using a Miniconda installation.
 
@@ -18,23 +18,23 @@ Consult your operating system instructions or system administrator to install th
 
 We will install the operations too using Python [Pip](https://pip.pypa.io/en/stable/), the Python Package Installer. If you have Python on your system, you probably already have Pip; you can run `pip3 --help` to check.
 
-It’s best install the tools virtual environment so it won’t interfere with—or be interfered by—other packages. To do so:
+It’s best install the tools virtual environment, so it won’t interfere with—or be interfered by—other packages. To do so:
 
 ```
 # Clone the repo or do a git pull if it already exists
 git clone https://github.com/NASA-PDS/pdsen-operations.git
-
+cd pdsen-operations
 
 # For Linux / Mac
 mkdir -p $HOME/.virtualenvs
 python3 -m venv $HOME/.virtualenvs/pdsen-ops
 source $HOME/.virtualenvs/pdsen-ops/bin/activate
-pip3 install -r build/requirements
+pip3 install -r build/requirements.txt
 ```
 
 ---
 
-# PDS Stats
+# pds-stats.py
 
 The `pds-stats.py` script can be used to get the total download metrics for Github software tools. Here is an example of how to get metrics for the Validate, MILabel, and Transform tools.
 
@@ -51,7 +51,7 @@ source $HOME/.virtualenvs/pdsen-ops/bin/activate
 2. Execute the script:
 
 ```
-bin/pds-stats.py --github_repos validate mi-label transform
+bin/pds-stats.py --github_repos validate mi-label transform --token $GITHUB_TOKEN
 ```
 
 ---

--- a/bin/ldds/ldd-corral.py
+++ b/bin/ldds/ldd-corral.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python
+"""
+LDD Corral
+
+Tool to corral all the LDDs 
+"""
+import logging
+import os
+
+import sys
+import traceback
+
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from datetime import datetime
+
+import yaml
+from github3 import login
+from lxml import etree
+from shutil import rmtree
+
+from pkg_resources import resource_string
+from pystache import Renderer
+
+from pds_github_util.assets.assets import unzip_asset
+from pds_github_util.branches.git_actions import clone_checkout_branch
+from pds_github_util.utils.ldd_gen import find_primary_ingest_ldd, convert_pds4_version_to_alpha
+
+# Github Org containing Discipline LDDs
+GITHUB_ORG = 'pds-data-dictionaries'
+
+# Namespace URI for PDS XML
+PDS_NS_URI = 'http://pds.nasa.gov/pds4/pds/v1'
+
+# Discipline LDD Dictionary Type Value
+DISC_LDD_DICT_TYPE = 'Discipline'
+
+STAGING_PATH = '/tmp/ldd-staging'
+OUTPUT_PATH = '/tmp/ldd-release'
+
+RELEASE_SUBDIR = "pds4"
+
+# default LDD Version currently set to v1 since unsure how LDDTool handles this
+LDD_VERSION_DEFAULT = 'v1'
+
+# LDD package file name suffix (Zip file)
+LDD_PACKAGE_SUFFIX = 'zip'
+
+# Report Filename
+LDD_REPORT = "dd-summary.shtml"
+
+# LDD Default Order
+LDD_FILES_THAT_MATTER = ['xsd', 'sch', 'xml', 'json', 'zip']
+
+# Default Issues URL
+ISSUES_URL = "https://github.com/pds-data-dictionaries/PDS4-LDD-Issue-Repo/issues"
+
+# HTML list template
+LDD_TOC_TEMPLATE = '				<li><a href="#{}">{}</a></li>\n'
+
+# LDD configuration base directory
+LDD_CONF_DIR = os.path.join('..', '..', 'conf', 'ldds')
+
+# LDD templates dir
+LDD_TEMPLATES_DIR = os.path.join('..', '..', 'conf', 'ldds', 'templates')
+
+# Quiet github3 logging
+logger = logging.getLogger('github3')
+logger.setLevel(level=logging.WARNING)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def generate_release(token, gh, args):
+    """Get Discipline Repos from Org.
+    Loop through repos in Github org to determine if it is a discipline LDD
+    """
+    _ldd_summary = {}
+    _pds4_alpha_version = convert_pds4_version_to_alpha(args.pds4_version)
+    _config = load_config()
+
+    for _repo in gh.repositories_by(args.github_org):
+        logger.info(f'checking {_repo.name}')
+        _dldd_repo = None
+
+        # get the ingestLDD file from the repo
+        _ingest_ldd = get_ingest_ldd(token, _repo)
+
+        if _ingest_ldd and _repo.name != "ldd-template":
+            _ldd_assets = []
+
+            # extract dictionary type and namespace id from ingestLDD
+            _ldd_name, _dict_type, _ns_id = extract_metadata(_ingest_ldd)
+
+            # check if this is a discipline LDD
+            if is_discipline_ldd(_repo, _dict_type, _config):
+                logger.info(f'discipline LDD found {_repo.name}')
+                _ldd_summary_repo = _ldd_summary[_repo.name] = {}
+                _ldd_summary_repo['repo'] = _repo
+
+                _ldd_summary_repo['name'] = _ldd_name
+                if 'name' in _config[_repo.name]:
+                    _ldd_summary_repo['name'] = _config[_repo.name]['name'] or _ldd_name
+
+                _ldd_summary_repo['ns_id'] = _ns_id
+                _dldd_repo = _repo.refresh()
+
+                # get latest release
+                _ldd_summary_repo['release'] = get_latest_tag_for_pds4_version(_dldd_repo, _pds4_alpha_version)
+
+                # let's download and unpack the release assets
+                _ldd_assets = prep_assets_for_release(_ldd_summary_repo['release'],
+                                                      os.path.join(args.output, RELEASE_SUBDIR,
+                                                                   _ldd_summary_repo['ns_id'],
+                                                                   LDD_VERSION_DEFAULT))
+
+                _ldd_summary_repo['assets'] = _ldd_assets
+
+    # generate output report
+    generate_report(_ldd_summary, args.pds4_version, _pds4_alpha_version, args.output, _config)
+
+
+def cleanup_dir(path):
+    if os.path.isdir(path):
+        rmtree(path)
+
+    os.makedirs(path)
+
+
+def get_ingest_ldd(token, repo):
+    """Get ingest ldd from repo.
+    """
+    # Cleanup in case repo already exists
+    _staging = f'{STAGING_PATH}/{repo}'
+    cleanup_dir(_staging)
+
+    _remote_url = repo.git_url.replace('git://', f'https://{token}:x-oauth-basic@')
+    cloned_repo = clone_checkout_branch(_remote_url, _staging, 'master')
+
+    return find_primary_ingest_ldd(f'{cloned_repo.working_tree_dir}/src')
+
+
+def extract_metadata(ingest_ldd):
+    """Extract metadata from ingestLDD.
+
+    Uses XPath to pull out specific metadata needed by other processes. Currently:
+    * //Ingest_LDD/dictionary_name
+    * //Ingest_LDD/dictionary_type
+    * //Ingest_LDD/namespace_id
+    """
+    _dict_name = None
+    _dict_type = None
+    _ns_id = None
+    with open(ingest_ldd[0], 'r') as f:
+        _tree = etree.parse(f)
+        _root = _tree.getroot()
+        if _tree.getroot().tag == f'{{{PDS_NS_URI}}}Ingest_LDD':
+            # get name
+            _matches = _root.findall(f'./{{{PDS_NS_URI}}}name')
+            if _matches:
+                _dict_name = _matches[0].text.strip()
+
+            # get dictionary type
+            _matches = _root.findall(f'./{{{PDS_NS_URI}}}dictionary_type')
+            if _matches:
+                _dict_type = _matches[0].text.strip()
+
+            # get namespace id
+            _matches = _root.findall(f'./{{{PDS_NS_URI}}}namespace_id')
+            if _matches:
+                _ns_id = _matches[0].text.strip()
+
+    return _dict_name, _dict_type, _ns_id
+
+
+def is_discipline_ldd(repo, dict_type, config):
+    if dict_type == DISC_LDD_DICT_TYPE or repo.name in config.keys():
+        return True
+
+    return False
+
+
+def prep_assets_for_release(release, output_path):
+    logger.info(f'downloading assets to {output_path}')
+    cleanup_dir(output_path)
+
+    _ldd_assets = {}
+    if release and release.assets():
+        for _asset in release.assets():
+            if _asset.name.lower().endswith(LDD_PACKAGE_SUFFIX) and 'dependencies' not in _asset.name.lower():
+                logger.info(f'Downloading asset {_asset.name}')
+                _output = os.path.join(output_path, _asset.name)
+                _asset.download(path=_output)
+
+                unzip_asset(_output, output_path)
+
+                for root, dirs, files in os.walk(output_path):
+                    for file in files:
+                        if 'ingestldd' not in file.lower():
+                            for _suffix in LDD_FILES_THAT_MATTER:
+                                if file.lower().endswith(_suffix):
+                                    _ldd_assets[_suffix] = (os.path.join(root, file))
+
+    return _ldd_assets
+
+
+def get_latest_tag_for_pds4_version(dldd_repo, pds4_alpha_version):
+    _sorted_releases = []
+    for _release in dldd_repo.releases():
+        if pds4_alpha_version in _release.name:
+            _sorted_releases.append({'date': _release.created_at, 'release': _release})
+
+    _latest_release = None
+    if _sorted_releases:
+        # sort the releases by date - probably should extract LDD version here but let's try this out for now
+        _sorted_releases.sort(key=lambda t: t['date'])
+
+        # get the latest release
+        _latest_release = _sorted_releases[len(_sorted_releases) - 1]['release']
+
+    return _latest_release
+
+
+def generate_report(ldd_summary, pds4_version, pds4_alpha_version, output, config):
+    _ldd_html_block = ""
+    _ldd_toc = ""
+    for _repo_name in ldd_summary.keys():
+        _ldd_summary_repo = ldd_summary[_repo_name]
+        _assets = _ldd_summary_repo['assets']
+        _description = config[_ldd_summary_repo['repo'].name]['description']
+        if _assets:
+            _pystache_dict = {
+                'ns_id': _ldd_summary_repo['ns_id'],
+                'title': _ldd_summary_repo['name'],
+                'description': _description,
+                'release_date': datetime.strftime(_ldd_summary_repo['release'].published_at, '%m/%d/%Y'),
+                'xsd_path': _assets['xsd'].replace(OUTPUT_PATH, ''),
+                'xsd_fname': os.path.basename(_assets['xsd']),
+                'sch_path': _assets['sch'].replace(OUTPUT_PATH, ''),
+                'sch_fname': os.path.basename(_assets['sch']),
+                'xml_path': _assets['xml'].replace(OUTPUT_PATH, ''),
+                'xml_fname': os.path.basename(_assets['xml']),
+                'json_path': _assets['json'].replace(OUTPUT_PATH, ''),
+                'json_fname': os.path.basename(_assets['json']),
+                'zip_path': _assets['zip'].replace(OUTPUT_PATH, ''),
+                'zip_fname': os.path.basename(_assets['zip']),
+                'issues_url': ISSUES_URL,
+                'github_url': _ldd_summary_repo['repo'].homepage or _ldd_summary_repo['repo'].clone_url.replace('.git', '')
+            }
+            _renderer = Renderer()
+            _template = resource_string(__name__, os.path.join(LDD_TEMPLATES_DIR, 'ldd.template.html'))
+            _ldd_html_block += _renderer.render(_template, _pystache_dict)
+        else:
+            # Discipline LDD was not release. use alternate template
+            _pystache_dict = {
+                'ns_id': _ldd_summary_repo['ns_id'],
+                'title': _ldd_summary_repo['name'],
+                'description': _description,
+                'issues_url': ISSUES_URL,
+                'github_url': _ldd_summary_repo['repo'].homepage or _ldd_summary_repo['repo'].clone_url.replace('.git', '')
+            }
+            _renderer = Renderer()
+            _template = resource_string(__name__, os.path.join(LDD_TEMPLATES_DIR, 'ldd-alternate.template.html'))
+            _ldd_html_block += _renderer.render(_template, _pystache_dict)
+
+        # Build up LDD TOC
+        _ldd_toc += LDD_TOC_TEMPLATE.format(_ldd_summary_repo['ns_id'], _ldd_summary_repo['name'])
+
+    with open(os.path.join(output, LDD_REPORT), 'w') as f_out:
+        _pystache_dict = {
+            'ldd_block': _ldd_html_block,
+            'ldd_toc': _ldd_toc,
+            'pds4_version': pds4_version,
+            'pds4_alpha_version': pds4_alpha_version
+        }
+
+        _renderer = Renderer()
+        _template = resource_string(__name__, os.path.join(LDD_TEMPLATES_DIR, 'dd-summary.template.shtml'))
+        html_str = _renderer.render(_template, _pystache_dict)
+        f_out.write(html_str)
+
+    logger.info(f'Output summary generated at: {os.path.join(output, LDD_REPORT)}')
+
+
+def load_config():
+    _config = yaml.load(resource_string(__name__, os.path.join(LDD_CONF_DIR, 'config.yml')), Loader=yaml.FullLoader)
+    return _config
+
+
+def main():
+    """main"""
+    parser = ArgumentParser(formatter_class=RawDescriptionHelpFormatter,
+                            description=__doc__)
+
+    parser.add_argument('--output',
+                        help='directory to output the generated page and dictionaries',
+                        default=OUTPUT_PATH)
+    parser.add_argument('--github_org',
+                        help=('github org to search repos for discipline LDDs. NOTE: these repos must contain ' +
+                              'src/IngestLDD'),
+                        default=GITHUB_ORG)
+    parser.add_argument('--pds4_version',
+                        help='PDS4 version to be used. Format example: 1.15.0.0',
+                        required=True)
+    parser.add_argument('--token',
+                        help='github token.')
+
+    args = parser.parse_args()
+
+    token = args.token or os.environ.get('GITHUB_TOKEN')
+    if not token:
+        logger.error(f'Github token must be provided or set as environment variable (GITHUB_TOKEN).')
+        sys.exit(1)
+
+    try:
+        # connect to github
+        gh = login(token=token)
+
+        # get all the discipline repos
+        generate_release(token, gh, args)
+
+    except Exception as e:
+        traceback.print_exc()
+        sys.exit(1)
+
+    logger.info(f'Data Dictionaries have been output to {args.output}')
+    logger.info(f'SUCCESS: LDD Corral complete.')
+
+
+if __name__ == '__main__':
+    main()

--- a/build/requirements.txt
+++ b/build/requirements.txt
@@ -1,1 +1,0 @@
-pds-github-util

--- a/conf/ldds/config.yml
+++ b/conf/ldds/config.yml
@@ -1,0 +1,67 @@
+ldd-alt:
+  description: |
+    The Alternate dictionary contains classes that describe sets of data values which are
+    interchangeable with each other.
+ldd-cart:
+  description: |
+    The Cartography Dictionary contains classes, elements, attributes, and rules describing map projections, including
+    both cartographic and lander related definitions and descriptions. The PDS Cartography dictionary is based on and
+    with modifications and extensions applied by PDS as needed for planetary mapping application.
+    utilizes the existing Federal Geographic Data Committee (FGDC) Content Standard for Digital Geospatial Metadata,
+ldd-ctli:
+  name: "Context Type List: Instrument"
+  description: |
+    The CTLI dictionary provides a set of type values for instruments for use in instrument context products.
+ldd-disp:
+  description: |
+    The Display Dictionary contains classes, attributes, and rules for specifying how arrays (images) as stored, should be displayed to users. For example, defining the vertical display direction 'Bottom to Top' or horizontal direction 'Left to Right' and it can provide guidance on mapping multiband arrays for color display (red, green, and blue) or as a movie sequence (video).
+ldd-exo:
+  description: |
+    The exoPlanet Dictionary (namespace: exo) contains classes, attributes, and rules for specifying metadata associated with exoPlanet stars and planets. The dictionary can provide guidance on mapping multiband arrays.
+ldd-geom:
+  description: |
+    The Geometry Dictionary contains classes, attributes, and rules for specifying the geometry parameters associated with science observations.
+ldd-img:
+  description: |
+    The Imaging Dictionary contains classes, attributes, and rules for specifying the metadata associated with imaging and spectrometer data products.
+ldd-msn:
+  description: |
+    The sub-directory for the Mission Information class namespace.
+ldd-multi:
+  name: Multidimensional
+  description: |
+    The Multi dictionary contains classes that describe the composition of multidimensional data consisting of Array (and Array subclass) data objects. It provides a way to associated data objects and align the objects in general multi-dimensional structures.
+ldd-nucspec:
+  name: Nuclear Spectroscopy
+  description: |
+    The Nuclear Spectroscopy dictionary provides classes, attributes, and rules for describing the circumstances surrounding nuclear spectroscopy observations.
+ldd-particle:
+  description: |
+    The Particle dictionary contains classes that describe the composition of multidimensional particle data consisting of Array (and Array subclass) data objects.
+ldd-proc:
+  description: |
+    The Processing_Information Dictionary contains detailed information regarding the history of processing performed on data product(s) in order to produce the current product.
+ldd-rings:
+  description: |
+    The Rings Dictionary contains classes supporting planetary ring observations including ring-specific geometric parameters.
+ldd-spectral:
+  description: |
+    The Spectral (sp) Discipline Dictionary contains classes for defining the spectral bin characteristics (in wavelength, frequency, or wave number) of a data product.
+ldd-speclib:
+  description: |
+    The Spectral Library Data Dictionary defines the metadata terms that describe laboratory spectral measurements, including classification of the samples measured.
+ldd-img_surface:
+  description: |
+    The Surface Imaging Dictionary contains classes, attributes, and rules for specifying the metadata associated with imaging and spectrometer data products of surface missions.
+ldd-msn_surface:
+  description: |
+    The Surface Mission Dictionary contains classes, attributes, and rules for specifying metadata elements which are specific to the data products of surface missions but are common among multiple such missions.
+ldd-survey:
+  description: |
+    The Survey dictionary provides classes, attributes, and rules for describing the circumstances surrounding sky survey observations.
+ldd-wave:
+  description: |
+    The Wave dictionary contains classes that describe the composition of multidimensional wave data consisting of Array (and Array subclass) data objects.
+ldd-msss_cam_mh:
+  description: |
+    This dictionary is for a class of cameras developed by Malin Space Science Systems (MSSS) that share a common architecture or digital electronics assembly. Example cameras include Mastcam, MAHLI, MARDI, Mastcam-Z, SHERLOC-Watson and SHERLOC-ACI

--- a/conf/ldds/templates/dd-summary.template.shtml
+++ b/conf/ldds/templates/dd-summary.template.shtml
@@ -1,0 +1,203 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><!-- InstanceBegin template="/Templates/main.dwt" codeOutsideHTMLIsLocked="false" -->
+<head>
+	<!-- InstanceBeginEditable name="doctitle" --><title>PDS: Data Dictionaries - {{pds4_version}}</title><!-- InstanceEndEditable -->
+	<!--#include virtual="/include/includes.html" -->
+	<!-- InstanceBeginEditable name="head" --><!-- InstanceEndEditable -->
+	<!-- InstanceParam name="menu_section" type="text" value="schema" -->
+	<!-- InstanceParam name="menu_item" type="text" value="pds4_schema" -->
+	<!-- InstanceParam name="left_sidebar" type="boolean" value="true" -->
+	<!-- InstanceParam name="standard_sidebar" type="boolean" value="true" -->
+
+	<script type="text/javascript" src="/js/ldd.js"></script>
+	<link href="/css/ldd.css" type="text/css" rel="stylesheet">
+</head>
+
+<body class="sidebar menu_datastandards menu_item_datastandards_schema">
+<!--[if IE]>
+<div id="IE">
+<![endif]--> 
+
+<div id="header-container">
+  <!--#include virtual="/include/header_logo.html" -->
+  <div id="menu-container">
+    <!--#include virtual="/include/main_menu.html" -->
+    <!--#include virtual="/include/datastandards_menu.html" -->
+  </div>
+  <!--#include virtual="/include/header_links.html" -->
+</div>
+
+<!-- Sidebar -->
+<div id="sidebar">
+	<!-- InstanceBeginEditable name="leftSidebar" -->
+	<!--#include virtual="/include/ldd_toc.html" -->
+	<!-- InstanceEndEditable -->
+</div>
+
+<!-- Main content -->
+<div id="content">
+	<h1><a name="mainContent"></a><!-- InstanceBeginEditable name="pageTitle" -->Data Dictionaries - {{pds4_version}}<!-- InstanceEndEditable --></h1>
+    <!-- InstanceBeginEditable name="content" -->
+	<div>
+		<p>
+			The following page links to version {{pds4_version}} of the PDS4 Data Dictionaries, including XML Schema and Schematrons for the applicable PDS4 namespace.
+		</p>
+		<p>
+            <b>Past versions of the data dictionaries can be found <a href="/datastandards/dictionaries/index-versions.shtml">here</a>.</b>
+		</p>
+		
+		<p>
+			Need help with creating a dictionary or where to start, please contact the <a href="mailto:pds_operator@jpl.nasa.gov">PDS Operator</a> at pds_operator@jpl.nasa.gov.
+		</p>
+	</div>
+	<hr />
+	<div id="ldd-search">
+		<h2>Data Dictionary Search</h2>
+		<p><a href="/datastandards/documents/dd/current/PDS4_PDS_DD_{{pds4_alpha_version}}/webhelp/all/">Browse and search</a> all data dictionary classes and attributes online.</p>
+		<hr />
+	</div>
+	<div id="ldd-intro">
+		<h2>What are you looking for?</h2>
+		<ul>
+			<li>The latest release of the main <a href="#pds-common">PDS Common</a> dictionary</li>
+			<li><a href="#discipline-dictionaries">Discipline dictionaries</a> to go with my main dictionary</li>
+			<li>A <a href="#mission-dictionaries">mission or project dictionary</a> from the archive</li>
+			<li>A <a href="#create-dictionary">how-to</a> on creating a dictionary</li>
+			<li>A <a href="#submit-new-version">how-to</a> on submitting my dictionary for archiving</li>
+			<li>Something else? See the <a href="#toc">Table of Contents</a> for more details</li>
+		</ul>
+	</div>
+	<hr />
+	<div id="data-dictionaries">
+		<h2>Data Dictionaries</h2>
+		<div id="compatible-versions">
+			<h3>Compatible Versions</h3>
+			<p>
+				For each version of the PDS Common Data Dictionary, there are specific discipline and mission dictionary that are compatible.
+				You can find this information in our <a href="/datastandards/schema/pds-dictionary-stacks.pdf">Dictionary Stacks</a> database.
+			</p>
+			<p><a class="toTop">Back to top</a></p>
+		</div>
+		<hr class="minihr">
+		<div id="pds-common" class="lddList">
+			<h3>PDS Common</h3>
+			<div>
+				<h4>PDS (pds)</h4>
+				<p>This directory contains the XML Schema and Schematron files under the Planetary Data System (PDS) namespace. The JSON file contains an instance of the data dictionary in JavaScript Object Notation.</p>
+				<ul>
+					<li><b>Last Updated:</b> 01/05/2020</li>
+					<ul>
+						<li><a href="/pds4/pds/v1/PDS4_PDS_{{pds4_alpha_version}}.xsd">PDS4_PDS_{{pds4_alpha_version}}.xsd</a></li>
+						<li><a href="/pds4/pds/v1/PDS4_PDS_{{pds4_alpha_version}}.sch">PDS4_PDS_{{pds4_alpha_version}}.sch</a></li>
+						<li><a href="/pds4/pds/v1/PDS4_PDS_{{pds4_alpha_version}}.xml">PDS4_PDS_{{pds4_alpha_version}}.xml</a></li>
+						<li><a href="/pds4/pds/v1/PDS4_PDS_JSON_{{pds4_alpha_version}}.JSON">PDS4_PDS_JSON_{{pds4_alpha_version}}.JSON</a></li>
+						<li><a href="/pds4/pds/v1/PDS4_PDS_{{pds4_alpha_version}}.zip">PDS4_PDS_{{pds4_alpha_version}}.zip</a></li>
+					</ul>
+				</ul>
+				<a class="toTop">Back to top</a>
+			</div>
+		</div>
+		<hr class="minihr">
+        <div id="discipline-dictionaries" class="lddList">
+            <h3>Discipline Dictionaries</h3>
+            <ul class="lddListToc">
+            {{{ldd_toc}}}
+            </ul>
+
+        {{{ldd_block}}}
+		</div>
+		<hr class="minihr">
+		<div id="mission-dictionaries">
+			<h3>Mission Dictionaries</h3>
+			<p>All versions of the Mission data dictionaries can be found <a href="/datastandards/dictionaries/index-missions.shtml">here</a>.</p>
+			<a class="toTop">Back to top</a>
+		</div>
+	</div>
+	<hr />
+	<div id="namespaces">
+		<h2>Namespaces</h2>
+		<p>
+			The PDS4 XML Schema and Schematron files are organized by namespace.
+			Links to documentation on a particular dictionary can be found <a href="https://github.com/pds-data-dictionaries/PDS-Data-Dictionaries.github.io/blob/master/docs/source/overview.md">here</a>.
+		</p>
+		<p>
+			For a list of existing namespaces, refer to the <a href="/datastandards/dictionaries/pds-namespace-registry.pdf">PDS Namespace Registry</a>.
+		</p>
+
+		<a class="toTop">Back to top</a>
+	</div>
+	<hr />
+	<div id="create-dictionary">
+		<h2>How To Create A Dictionary</h2>
+		<p>
+			Please contact your applicable discipline node to ensure a new dictionary is necessary prior to beginning development.
+			Once agreed upon, there are several places to go when trying to learn how to create a dictionary.
+		</p>
+		<ul>
+			<li>The <a href="https://pds.nasa.gov/datastandards/documents/sr/current/">PDS4 Standards Reference</a> for basic information on schema and schematrons</li><br>
+			<li><a href="https://nasa-pds.github.io/pds4-information-model/model-lddtool/install/index.html">Local Data Dictionary Tool Installation Guide</a></li><br>
+            <li>Wiki pages with some helpful information on creating Local Dictionaries:
+                <ul>
+                    <li><a href="http://sbndev.astro.umd.edu/wiki/Installing_and_Configuring_LDDTool">Installing and Configuring LDDTool</a></li>
+                    <li><a href="http://sbndev.astro.umd.edu/wiki/Creating_the_Ingest_LDD_Dictionary_Input_File">Creating the Ingest LDD Dictionary Input File</a></li>
+                    <li><a href="http://sbndev.astro.umd.edu/wiki/Running_LDDTool_and_Verifying_the_Output">Running LDDTool and Verifying the Output</a></li>
+                </ul>
+            </li><br />
+            <li>Existing <a href="#discipline-dictionaries">Discipline Dictionaries</a> may provide some help in understanding how to data model</li><br />
+		</ul>
+		<p>
+			In order for a newly created dictionary to be published, it must first be registered with the PDS Namespace Registry. 
+			Create a ticket <a href="https://github.com/NASA-PDS/pds4-information-model/issues/new?assignees=c-suh%2C+jshughes&labels=&template=pds-namespace-request.md&title=%5Bnamespace-registry%5D+add+new+namespace+%22%3Cproposed+namespace+ID%3E%22">here</a> to request your new <a href="#namespaces">namespace</a> be added to the registry.
+		</p>
+		
+		<a class="toTop">Back to top</a>
+	</div>
+	<hr />
+    <div id="submit-new-version">
+        <h2>Submitting A New Version</h2>
+        <p>
+            When a Local Data Dictionary (LDD) Steward is ready to submit a new version of an LDD for release,
+            create a request ticket <a href="https://github.com/NASA-PDS/pdsen-operations/issues/new?assignees=c-suh%2C+elawsgh&labels=ldd-release&template=pds-ldd-release-request.md&title=%5Bldd-release%5D+%3CLDD+Name%3E+LDD+Version%3A%3CLDD_version%3E+IM+Version%3A%3CIM_Version%3E">here</a>.
+        </p>
+        <p>
+            <em>Note: Assume <a href="#dictionary-validation">validation</a> has been completed by steward.</em>
+        </p>
+        <div id="dictionary-validation">
+            <h3>Dictionary Validation</h3>
+            <p>
+                The <b><em>LDD steward</em></b> is encouraged to perform test/validation via one/both of the testing mechanisms:
+            </p>
+            <p>
+                <em>Note: Currently, there is no explicit way to run validate to check out the schemas,
+                    but by reading the schemas into the tool, it will raise an error if they are invalid.</em>
+            </p>
+            <ul>
+                <li>Open in Oxygen and click the red checkbox at the top.</li>
+                <li>Execute latest validate (version 1.16.0+) and specify the schemas via the command-line, for example:
+                    <pre>$ validate -x PDS4_CART_1C00_1932.xsd -S PDS4_CART_1C00_1932.xsd -t PDS4_CART_1C00_1932.xml
+                    </pre></li>
+            </ul>
+            <p>
+                The <b><em>PDS Engineering Node</em></b> will also perform some basic testing and validation when a release
+                is requested to ensure nothing makes it out as &quot;released&quot; that is invalid.
+            </p>
+            <p>
+                If there is an error, an email will be sent to the steward with error message(s).
+            </p>
+            <p>
+                If no error is found, the LDD will be posted to both latest and all schemas pages.
+                An email will be sent to the steward indicating posting is completed.
+            </p>
+        </div>
+        <a class="toTop">Back to top</a>
+    </div>
+    <!-- InstanceEndEditable -->
+</div>
+
+<!--#include virtual="/include/footer.html" --
+
+<!--[if IE]>
+</div>
+<![endif]-->
+</body>
+	<!-- InstanceEnd --></html>

--- a/conf/ldds/templates/ldd-alternate.template.html
+++ b/conf/ldds/templates/ldd-alternate.template.html
@@ -1,0 +1,22 @@
+
+            <div id="{{ns_id}}">
+                <h4>{{title}} ({{ns_id}})</h4>
+                <p>
+                    {{description}}
+                </p>
+                <ul>
+                    <li><b>Last Updated:</b> {{release_date}}</li>
+                    <li><b>Issue Tracking:</b> <a href="{{issues_url}}">{{issues_url}}</a></li>
+                    <li><b>Github Repo:</b> <a href="{{github_url}}">{{github_url}}</a></li>
+                    <li><b>Data Dictionary Files:</b>
+                        <ul>
+                            <li><i>NOTE: A new version of this Local Data Dictionary was not generated with this version of the
+                                PDS4  Information Model. To submit a request the have the LDD generated, please contact the
+                                <a href="mailto:pds-operator@jpl.nasa.gov">PDS Operator</a>, or create an issue in the
+                                <a href="{{issues_url}}">PDS4 LDD Issues Repository</a></i>
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+                <p><a class="toTop">Back to top</a></p>
+            </div>

--- a/conf/ldds/templates/ldd.template.html
+++ b/conf/ldds/templates/ldd.template.html
@@ -1,0 +1,22 @@
+
+            <div id="{{ns_id}}">
+                <h4>{{title}} ({{ns_id}})</h4>
+                <p>
+                    {{description}}
+                </p>
+                <ul>
+                    <li><b>Last Updated:</b> {{release_date}}</li>
+                    <li><b>Issue Tracking:</b> <a href="{{issues_url}}">{{issues_url}}</a></li>
+                    <li><b>Github Repo:</b> <a href="{{github_url}}">{{github_url}}</a></li>
+                    <li><b>Data Dictionary Files:</b>
+                        <ul>
+                            <li><a href="{{xsd_path}}">{{xsd_fname}}</a></li>
+                            <li><a href="{{sch_path}}">{{sch_fname}}</a></li>
+                            <li><a href="{{xml_path}}">{{xml_fname}}</a></li>
+                            <li><a href="{{json_path}}">{{json_fname}}</a></li>
+                            <li><a href="{{zip_path}}">{{zip_fname}}</a></li>
+                        </ul>
+                    </li>
+                </ul>
+                <p><a class="toTop">Back to top</a></p>
+            </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pds-github-util
+pyyaml~=5.3.1
+github3.py~=1.3.0
+requests~=2.23.0
+lxml~=4.6.2
+pystache~=0.5.4


### PR DESCRIPTION
ldd-corral uses config and templates in conf/ldds dir to generate
the data dictionaries web page at release time.

migrated from pds-github-util.

refs #14 #5